### PR TITLE
Clean up placeholder comments

### DIFF
--- a/models/Appointments_model.php
+++ b/models/Appointments_model.php
@@ -1,9 +1,6 @@
 <?php
-defined('BASEPATH') or exit('No direct script access allowed');
 
-/**
- * Step 3: Create this file as modules/cases/models/Appointments_model.php
- */
+defined('BASEPATH') or exit('No direct script access allowed');
 
 class Appointments_model extends App_Model
 {

--- a/views/appointments/manage.php
+++ b/views/appointments/manage.php
@@ -1,12 +1,6 @@
 <?php defined('BASEPATH') or exit('No direct script access allowed'); ?>
 <?php init_head(); ?>
 
-<?php
-/**
- * Step 5A: Create this file as modules/cases/views/appointments/manage.php
- */
-?>
-
 <style>
 /* Consistent with your existing Cases module styling */
 * {


### PR DESCRIPTION
## Summary
- remove leftover step comments from the appointments model and view
- tidy file spacing

## Testing
- `php -l models/Appointments_model.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449dba15b88326a343f997124d7ddc