### PR TITLE
Add appointment tables to installer

### DIFF
--- a/install.php
+++ b/install.php
@@ -95,3 +95,156 @@ if (!$CI->db->table_exists(db_prefix() . 'interim_applications')) {
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
     ");
 }
+
+// Create appointments table
+if (!$CI->db->table_exists(db_prefix() . 'appointments')) {
+    $CI->db->query("
+        CREATE TABLE `" . db_prefix() . "appointments` (
+            `id` INT(11) NOT NULL AUTO_INCREMENT,
+            `client_id` INT(11) NOT NULL,
+            `contact_id` INT(11) DEFAULT NULL,
+            `service_id` INT(11) NOT NULL,
+            `staff_id` INT(11) NOT NULL,
+            `appointment_date` DATE NOT NULL,
+            `start_time` TIME NOT NULL,
+            `end_time` TIME NOT NULL,
+            `duration_minutes` INT(11) NOT NULL,
+            `status` ENUM('pending','confirmed','completed','cancelled','no_show','rescheduled') DEFAULT 'pending',
+            `notes` TEXT DEFAULT NULL,
+            `internal_notes` TEXT DEFAULT NULL,
+            `invoice_id` INT(11) DEFAULT NULL,
+            `booking_invoice_id` INT(11) DEFAULT NULL,
+            `consultation_id` INT(11) DEFAULT NULL,
+            `total_amount` DECIMAL(15,2) DEFAULT 0.00,
+            `paid_amount` DECIMAL(15,2) DEFAULT 0.00,
+            `payment_status` ENUM('unpaid','partial','paid','refunded','cancelled') DEFAULT 'unpaid',
+            `payment_required` TINYINT(1) DEFAULT 0,
+            `auto_invoice` TINYINT(1) DEFAULT 1,
+            `booked_by` ENUM('client','staff','online') DEFAULT 'staff',
+            `booking_source` VARCHAR(50) DEFAULT 'dashboard',
+            `confirmation_key` VARCHAR(32) DEFAULT NULL,
+            `cancellation_reason` TEXT DEFAULT NULL,
+            `rescheduled_from` INT(11) DEFAULT NULL,
+            `confirmation_sent` TINYINT(1) DEFAULT 0,
+            `reminder_sent` TINYINT(1) DEFAULT 0,
+            `reminder_count` INT(11) DEFAULT 0,
+            `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+            `updated_at` DATETIME DEFAULT NULL,
+            `created_by` INT(11) DEFAULT NULL,
+            `updated_by` INT(11) DEFAULT NULL,
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+    ");
+}
+
+// Create appointment_services table
+if (!$CI->db->table_exists(db_prefix() . 'appointment_services')) {
+    $CI->db->query("
+        CREATE TABLE `" . db_prefix() . "appointment_services` (
+            `id` INT(11) NOT NULL AUTO_INCREMENT,
+            `name` VARCHAR(255) NOT NULL,
+            `description` TEXT DEFAULT NULL,
+            `duration_minutes` INT(11) NOT NULL DEFAULT 60,
+            `price` DECIMAL(15,2) NOT NULL DEFAULT 0.00,
+            `currency` INT(11) NOT NULL DEFAULT 1,
+            `tax_id` INT(11) DEFAULT NULL,
+            `tax_id_2` INT(11) DEFAULT NULL,
+            `item_id` INT(11) DEFAULT NULL,
+            `requires_prepayment` TINYINT(1) NOT NULL DEFAULT 0,
+            `booking_fee` DECIMAL(15,2) DEFAULT 0.00,
+            `cancellation_fee` DECIMAL(15,2) DEFAULT 0.00,
+            `color` VARCHAR(7) DEFAULT '#1a6bcc',
+            `active` TINYINT(1) NOT NULL DEFAULT 1,
+            `sort_order` INT(11) DEFAULT 0,
+            `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+            `updated_at` DATETIME DEFAULT NULL,
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+    ");
+}
+
+// Create appointment_staff_services table
+if (!$CI->db->table_exists(db_prefix() . 'appointment_staff_services')) {
+    $CI->db->query("
+        CREATE TABLE `" . db_prefix() . "appointment_staff_services` (
+            `id` INT(11) NOT NULL AUTO_INCREMENT,
+            `staff_id` INT(11) NOT NULL,
+            `service_id` INT(11) NOT NULL,
+            `custom_price` DECIMAL(15,2) DEFAULT NULL,
+            `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+    ");
+}
+
+// Create appointment_staff_availability table
+if (!$CI->db->table_exists(db_prefix() . 'appointment_staff_availability')) {
+    $CI->db->query("
+        CREATE TABLE `" . db_prefix() . "appointment_staff_availability` (
+            `id` INT(11) NOT NULL AUTO_INCREMENT,
+            `staff_id` INT(11) NOT NULL,
+            `day_of_week` TINYINT(1) NOT NULL,
+            `start_time` TIME NOT NULL,
+            `end_time` TIME NOT NULL,
+            `break_start` TIME DEFAULT NULL,
+            `break_end` TIME DEFAULT NULL,
+            `is_available` TINYINT(1) DEFAULT 1,
+            `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+            `updated_at` DATETIME DEFAULT NULL,
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+    ");
+}
+
+// Create appointment_blocked_times table
+if (!$CI->db->table_exists(db_prefix() . 'appointment_blocked_times')) {
+    $CI->db->query("
+        CREATE TABLE `" . db_prefix() . "appointment_blocked_times` (
+            `id` INT(11) NOT NULL AUTO_INCREMENT,
+            `staff_id` INT(11) NOT NULL,
+            `start_datetime` DATETIME NOT NULL,
+            `end_datetime` DATETIME NOT NULL,
+            `reason` VARCHAR(255) DEFAULT NULL,
+            `is_recurring` TINYINT(1) DEFAULT 0,
+            `recurring_type` ENUM('daily','weekly','monthly') DEFAULT NULL,
+            `recurring_until` DATE DEFAULT NULL,
+            `created_by` INT(11) NOT NULL,
+            `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+    ");
+}
+
+// Create appointment_payments table
+if (!$CI->db->table_exists(db_prefix() . 'appointment_payments')) {
+    $CI->db->query("
+        CREATE TABLE `" . db_prefix() . "appointment_payments` (
+            `id` INT(11) NOT NULL AUTO_INCREMENT,
+            `appointment_id` INT(11) NOT NULL,
+            `invoice_id` INT(11) NOT NULL,
+            `payment_type` ENUM('booking_fee','service_fee','full_payment','cancellation_fee','refund') NOT NULL,
+            `amount` DECIMAL(15,2) NOT NULL,
+            `payment_date` DATETIME DEFAULT NULL,
+            `payment_method` VARCHAR(50) DEFAULT NULL,
+            `transaction_id` VARCHAR(255) DEFAULT NULL,
+            `notes` TEXT DEFAULT NULL,
+            `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+    ");
+}
+
+// Create appointment_settings table
+if (!$CI->db->table_exists(db_prefix() . 'appointment_settings')) {
+    $CI->db->query("
+        CREATE TABLE `" . db_prefix() . "appointment_settings` (
+            `id` INT(11) NOT NULL AUTO_INCREMENT,
+            `setting_name` VARCHAR(100) NOT NULL,
+            `setting_value` TEXT DEFAULT NULL,
+            `setting_type` VARCHAR(50) DEFAULT 'text',
+            `description` TEXT DEFAULT NULL,
+            `updated_at` DATETIME DEFAULT NULL,
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+    ");
+}


### PR DESCRIPTION
## Summary
- expand installation to include appointment tables

## Testing
- `php -l install.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449db2461c832693cd1134207881f4